### PR TITLE
Fix codegen script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ A new implementation of the webcompoents.org site
 
 This repo will contain several packages:
 
-* A data-only backend that indexes npm packages and provides a GraphQL API into the database
-* A frontend server that serves the user-facing webcompoents.org site
-* An HTML client served by the frontend server
+- A data-only backend that indexes npm packages and provides a GraphQL API into the database
+- A frontend server that serves the user-facing webcompoents.org site
+- An HTML client served by the frontend server
+
+## Quick Start
+
+```bash
+npm ci
+npm run bootstrap
+cd packages/wc-registry
+npm run build
+npm run emulators:start & npm run dev
+```

--- a/packages/wc-registry/package.json
+++ b/packages/wc-registry/package.json
@@ -18,7 +18,7 @@
     "build": "npm run build:graphql && npm run build:ts && npm run build:copy",
     "build:ts": "../../node_modules/.bin/tsc",
     "build:copy": "cp -r out/{src,gen}/* .",
-    "build:graphql": "graphql-codegen",
+    "build:graphql": "graphql-codegen -c codegen.yml",
     "emulators:start": "firebase emulators:start --project wc-catalog",
     "firebase": "firebase",
     "test": "echo \"Error: run tests from root\" && exit 1"


### PR DESCRIPTION
Prevent

<details><summary>Unable to find any GraphQL type definitions for the following pointers:</summary>

```
> wc-registry@0.0.0 build:graphql
> graphql-codegen

  ✔ Parse configuration
  ❯ Generate outputs
    ❯ Generate src/schema.ts
      ✔ Load GraphQL schemas
      ✖ Load GraphQL documents
        →           - src/**/*.subscription.graphql
        Generate


 Found 1 error

  ✖ src/schema.ts
    Error:
          Unable to find any GraphQL type definitions for the following pointers:

              - src/**/*.fragment.graphql
              ,
              - src/**/*.mutation.graphql
              ,
              - src/**/*.query.graphql
              ,
              - src/**/*.subscription.graphql

        at prepareResult (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-tools/load/index.cjs.js:591:15)
        at loadTypedefs (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-tools/load/index.cjs.js:556:12)
        at processTicksAndRejections (node:internal/process/task_queues:94:5)
        at async CodegenContext.loadDocuments (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:737:31)
        at async /Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:916:55
        at async Task.task (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:760:17)
    Error:
          Unable to find any GraphQL type definitions for the following pointers:

              - src/**/*.fragment.graphql
              ,
              - src/**/*.mutation.graphql
              ,
              - src/**/*.query.graphql
              ,
              - src/**/*.subscription.graphql

        at prepareResult (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-tools/load/index.cjs.js:591:15)
        at loadTypedefs (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-tools/load/index.cjs.js:556:12)
        at processTicksAndRejections (node:internal/process/task_queues:94:5)
        at async CodegenContext.loadDocuments (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:737:31)
        at async /Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:916:55
        at async Task.task (/Users/bennyp/Developer/wc-catalog/packages/wc-registry/node_modules/@graphql-codegen/cli/bin.js:760:17)
```

</details>

Also add quick start to readme